### PR TITLE
Add BSD3 license for Muselab LLC and add test cases and a test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+
+      - name: Run tests
+        run: |
+          pytest

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Muselab LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,18 @@ None
 This action includes logic to manage sessions for accessing Salesforce credentials. When a session is ended, it triggers logic to revoke the Salesforce grant and delete the session environment from GitHub.
 
 To end a session, set a flag in your workflow to trigger the cleanup logic. The action will then revoke the Salesforce grant and delete the session environment.
+
+## Running Tests
+
+To run tests for this project, follow these steps:
+
+1. Install the required dependencies:
+   ```sh
+   python -m pip install --upgrade pip
+   pip install pytest
+   ```
+
+2. Run the tests using `pytest`:
+   ```sh
+   pytest
+   ```

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+import requests
+import pytest
+from main import (
+    get_inputs,
+    get_access_token_and_instance_url,
+    create_session_environment,
+    revoke_salesforce_grant,
+    delete_session_environment
+)
+
+def test_get_inputs(monkeypatch):
+    monkeypatch.setenv('INPUT_SFDX_AUTH_URL', 'test_sfdx_auth_url')
+    monkeypatch.setenv('INPUT_GITHUB_TOKEN', 'test_github_token')
+    sfdx_auth_url, github_token = get_inputs()
+    assert sfdx_auth_url == 'test_sfdx_auth_url'
+    assert github_token == 'test_github_token'
+
+def test_get_access_token_and_instance_url(mocker):
+    mocker.patch('subprocess.run', return_value=subprocess.CompletedProcess(
+        args=['d2x', 'auth', 'sf', 'url', 'test_sfdx_auth_url'],
+        returncode=0,
+        stdout='access_token=test_access_token\ninstance_url=test_instance_url'
+    ))
+    access_token, instance_url = get_access_token_and_instance_url('test_sfdx_auth_url')
+    assert access_token == 'test_access_token'
+    assert instance_url == 'test_instance_url'
+
+def test_create_session_environment(mocker):
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {'id': 'test_environment_id'}
+    mocker.patch('requests.post', return_value=mock_response)
+    github_token = 'test_github_token'
+    response = create_session_environment(github_token)
+    assert response['id'] == 'test_environment_id'
+
+def test_revoke_salesforce_grant(mocker):
+    mock_response = mocker.Mock()
+    mocker.patch('requests.post', return_value=mock_response)
+    access_token = 'test_access_token'
+    instance_url = 'test_instance_url'
+    revoke_salesforce_grant(access_token, instance_url)
+    mocker.patch('requests.post').assert_called_once_with(
+        f'{instance_url}/services/oauth2/revoke',
+        headers={
+            'Authorization': f'Bearer {access_token}',
+            'Content-Type': 'application/json'
+        }
+    )
+
+def test_delete_session_environment(mocker):
+    mock_response = mocker.Mock()
+    mocker.patch('requests.delete', return_value=mock_response)
+    github_token = 'test_github_token'
+    delete_session_environment(github_token)
+    mocker.patch('requests.delete').assert_called_once_with(
+        'https://api.github.com/repos/githubnext/workspace-blank/environments',
+        headers={
+            'Authorization': f'token {github_token}',
+            'Accept': 'application/vnd.github.v3+json'
+        }
+    )


### PR DESCRIPTION
Add BSD3 license, test cases, and test workflow.

* **LICENSE**
  - Add BSD3 license text for Muselab LLC.

* **Tests**
  - Add test cases for `get_inputs`, `get_access_token_and_instance_url`, `create_session_environment`, `revoke_salesforce_grant`, and `delete_session_environment` functions in `tests/test_main.py`.

* **Test Workflow**
  - Add a test workflow in `.github/workflows/test.yml` to run tests using `pytest`.
  - Set the workflow to run on push and pull request events.
  - Use `actions/checkout@v2` to check out the repository.
  - Use `actions/setup-python@v2` to set up Python.
  - Install dependencies and run tests using `pytest`.

* **README.md**
  - Add a section for running tests.
  - Include instructions to run tests using `pytest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muselab-d2x/action-sf-org-session?shareId=679e58da-ba79-4171-b511-d5b30f0272ab).